### PR TITLE
make availableLanguages optional in the constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 | Version | Date       | Changes    |
 | ------- | ---------- | ---------- |
+| 0.2.3   | 2024-11-20 | - make availableLanguages optional again in QuestionnaireData constructor |
 | 0.2.2   | 2024-08-28 | - add isTouched() |
 | 0.2.1   | 2023-03-22 | - remove unneeded logging |
 | 0.2.0   | 2023-03-21 | - add getQuestionnaireDescription()<br />- add isQuestionComplete()<br />- generate narrative for QuestionnaireResponse<br />- field `midataExtensions` added to getQuestionnaireResponse() options<br />- support initial values<br />- add tests (coverage >80%)<br />- various bugfixes |

--- a/README.md
+++ b/README.md
@@ -19,13 +19,14 @@ npm install @i4mi/fhir_questionnaire
 ```
 Wait for the install to complete and you are ready to set up QuestionnaireData.
 ### Setup
-For every questionnaire you want to handle, you need to initialize a QuestionnaireData instance, providing the FHIR questionnaire resource as a JSON object, and at least one shorthand for an available language:
+For every questionnaire you want to handle, you need to initialize a QuestionnaireData instance, providing the FHIR questionnaire resource as a JSON object.
+
 ```typescript
 import {QuestionnaireData} from '@i4mi/fhir_questionnaire';
 
 // ... other code
 
-const qData = new QuestionnaireData(fhirQuestionnaire, ['en']);
+const qData = new QuestionnaireData(fhirQuestionnaire);
 ```
 
 #### External ValueSets

--- a/__tests__/i18n.test.ts
+++ b/__tests__/i18n.test.ts
@@ -2,6 +2,7 @@ import {Questionnaire, QuestionnaireResponse} from '@i4mi/fhir_r4';
 import {QuestionnaireData} from '../dist/QuestionnaireData';
 
 const I18N_QUESTIONNAIRE = require('./questionnaires/i18n.json') as Questionnaire;
+const EMPTY_QUESTIONNAIRE = require('./questionnaires/empty.json') as Questionnaire;
 
 const LANGUAGES = ['de', 'fr', 'it']; // 'it' is not in Questionnaire
 const testData = new QuestionnaireData(I18N_QUESTIONNAIRE, LANGUAGES);
@@ -88,4 +89,17 @@ test('getQuestionnaireResponse', () => {
   expect(response.it).toBeDefined();
   // it is fallback, since the questionnaire has no IT strings
   expect(response.de).toEqual(response.it);
+});
+
+const testDataSimple = new QuestionnaireData(I18N_QUESTIONNAIRE);
+test('simpleAvailableLanguages', () => {
+  expect(testDataSimple.availableLanguages).toEqual(['de', 'fr']);
+});
+
+test('loadEmptyQuestionnaire', () => {
+  let testDataEmpty: QuestionnaireData | undefined;
+  expect(() => {
+    testDataEmpty = new QuestionnaireData(EMPTY_QUESTIONNAIRE);
+  }).not.toThrow();
+  expect(testDataEmpty?.availableLanguages).toEqual([]);
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@i4mi/fhir_questionnaire",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@i4mi/fhir_questionnaire",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@i4mi/fhir_r4": "^2.0.0",
@@ -2021,9 +2021,9 @@
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
       "dependencies": {
         "path-key": "^3.1.0",
@@ -7580,9 +7580,9 @@
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
     },
     "cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
       "requires": {
         "path-key": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@i4mi/fhir_questionnaire",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "TS Package for handling FHIR Questionnaire and generating QuestionnaireRespones.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Adding `availableLanguages` to the constructor caused some backward incompatibilities. Version 0.2.3 makes availableLanguages optional again; and tries it to recognize from the questionnaire when no argument is passed.